### PR TITLE
🐛 [bug] 지도에서 ShopInfoSheet 안 뜨는 오류 해결

### DIFF
--- a/VINNY/VINNY/Source/Feature/Map/MapDetails/MapTopView.swift
+++ b/VINNY/VINNY/Source/Feature/Map/MapDetails/MapTopView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MapTopView: View {
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             HStack(spacing: 16) {
                 Text("지도")
                     .font(.suit(.bold, size: 24))
@@ -58,21 +58,26 @@ struct MapTopView: View {
                             .foregroundStyle(Color.backFillRegular)
                     )
                 
-                HStack(spacing: 2) {
-                    Image("reset")
-                        .resizable()
-                        .frame(width: 20, height: 20)
-                    
-                    Text("현 위치에서 검색")
-                        .font(.suit(.medium, size: 14))
-                        .foregroundStyle(Color.contentBase)
+                Button(action: {
+                    print("현 위치에서 검색")
+                    LocationManager.shared.startUpdatingLocation()
+                }) {
+                    HStack(spacing: 2) {
+                        Image("reset")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                        
+                        Text("현 위치에서 검색")
+                            .font(.suit(.medium, size: 14))
+                            .foregroundStyle(Color.contentBase)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .foregroundStyle(Color.backFillRegular)
+                    )
                 }
-                .frame(maxWidth: .infinity)
-                .padding(12)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .foregroundStyle(Color.backFillRegular)
-                )
                 
                 Image("icon")
                     .resizable()
@@ -86,6 +91,7 @@ struct MapTopView: View {
             .padding(.horizontal)
             .padding(.bottom, 14)
         }
+        .padding(.top, 54)
         .background(Color.backFillStatic)
         .ignoresSafeArea()
     }

--- a/VINNY/VINNY/Source/Feature/Map/MapDetails/MapView.swift
+++ b/VINNY/VINNY/Source/Feature/Map/MapDetails/MapView.swift
@@ -14,7 +14,7 @@ import UIKit
 struct MapView: View {
     
     @Bindable private var locationManager = LocationManager.shared
-    @Bindable private var viewModel: MapViewModel = .init()
+    @State private var viewModel: MapViewModel = .init()
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -22,12 +22,12 @@ struct MapView: View {
             
             MapTopView()
         }
-        .navigationBarBackButtonHidden()
-        .ignoresSafeArea()
         .sheet(item: $viewModel.selectedMarker) { marker in
             ShopInfoSheet(shopName: marker.title)
                 .presentationDetents([.height(300)])
         }
+        .navigationBarBackButtonHidden()
+        .ignoresSafeArea()
         .background(Color.backFillStatic)
     }
 }

--- a/VINNY/VINNY/Source/Feature/Map/MapDetails/MapViewModel.swift
+++ b/VINNY/VINNY/Source/Feature/Map/MapDetails/MapViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import MapKit
 import Observation
 
+@MainActor
 @Observable
 final class MapViewModel {
     
@@ -25,6 +26,7 @@ final class MapViewModel {
     ]
     
     var selectedMarker: Marker? = nil
+    
     
     init() {
         if let location = LocationManager.shared.currentLocation {


### PR DESCRIPTION
## 🐛 Bug

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
<img width="1125" height="2436" alt="IMG_6255" src="https://github.com/user-attachments/assets/49fbdff6-6bcf-4059-b9a3-a6f151dca623" />

> 기존의 mapView에서는 마커를 눌러도 ShopInfoSheet이 안 뜨는 문제가 있었음. <
- 원인은 MapView에서 MapViewModel를 @Bindable로 채택하고 있었어서.. @State로 바꾸니 해결됨
- Sheet을 띄우기 위해서는 내부 변화를 인식해야 하는데 @Bindable은 자체로 상태 추적이 안 되기 때문에 @Bindable을 썼을 때 제대로 작동하지 않았던 것..입니다

## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
- 이미지 픽커 기능 추가하기

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
