### PR TITLE
feat: 샵 검색시 샵 이미지 안보이는 문제 해결             

### DIFF
--- a/VINNY/VINNY/Source/Feature/Search/SearchResultCell.swift
+++ b/VINNY/VINNY/Source/Feature/Search/SearchResultCell.swift
@@ -13,6 +13,26 @@ import SwiftUI
 struct SearchResultCell: View {
     @EnvironmentObject var container: DIContainer
     let shops: Shops // 외부에서 주입받는 샵 데이터
+
+    // 샵 썸네일 URL 추출 (logoImage / imageUrl / imageUrls[0] 순서)
+    private var thumbnailURL: URL? {
+        let mirror = Mirror(reflecting: shops)
+        // 단일 문자열 필드 우선
+        if let logo = mirror.children.first(where: { $0.label == "logoImage" })?.value as? String,
+           logo.hasPrefix("http") {
+            return URL(string: logo)
+        }
+        if let single = mirror.children.first(where: { $0.label == "imageUrl" })?.value as? String,
+           single.hasPrefix("http") {
+            return URL(string: single)
+        }
+        // 배열 필드의 첫 번째
+        if let list = mirror.children.first(where: { $0.label == "imageUrls" })?.value as? [String],
+           let first = list.first, first.hasPrefix("http") {
+            return URL(string: first)
+        }
+        return nil
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) { // 셀 전체 구성 수직 스택
@@ -20,12 +40,15 @@ struct SearchResultCell: View {
                 
                 // 상단 이름 + 주소 + > 아이콘 줄
                 HStack(alignment: .center, spacing: 12) {
-                    // 프로필 이미지
-                    Image("example_profile") // 실제 이미지 에셋명으로 교체
-                        .resizable()
-                        .frame(width: 40, height: 40)
-                        .clipShape(Circle())
-                        .padding(.trailing, 12)
+                    // 프로필 이미지 (서버 URL 적용, 실패 시 플레이스홀더)
+                    AsyncImage(url: thumbnailURL) { image in
+                        image.resizable()
+                    } placeholder: {
+                        Image("emptyImage").resizable()
+                    }
+                    .frame(width: 40, height: 40)
+                    .clipShape(Circle())
+                    .padding(.trailing, 12)
                     
                     // 상호명 및 주소
                     VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## ✨ PR 유형
#88

어떤 변경 사항이 있나요??

샵 검색시 샵 이미지 안보이는 문제 해결     
- [x] 버그 수정



## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
샵 검색시 샵 이미지 안보이는 문제 해결     
<img width="287" height="591" alt="스크린샷 2025-08-21 오후 8 25 48" src="https://github.com/user-attachments/assets/c8111adc-e0fa-41f0-ad7a-2acc166d80e7" />


## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
